### PR TITLE
Added option for custom variable name to provide a way of avoiding conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ var options = {
   return_buffers: true,
   auth_pass: 'superSecretPassword'
 };
-app.use(require('express-redis')(6379, '127.0.0.1', options));
+app.use(require('express-redis')(6379, '127.0.0.1', options, 'name'));
 ```
+
+The name string allows you to specify a custom varaible name to provide the middleware on
+for example providing the name `'redis'` would allow you to access redis via `res.redis`
 

--- a/index.js
+++ b/index.js
@@ -18,13 +18,13 @@ module.exports = function (port, host, options) {
 
   var f = function (req, res, next) {
     if (client.connected) {
-      req.db = client;
+      req.redis = client;
       next();
     }
     else {
       client.on('ready', function () {
         debug('Redis connection ready.');
-        req.db = client;
+        req.redis = client;
         next();
       });
     }

--- a/index.js
+++ b/index.js
@@ -9,22 +9,23 @@ var debug = require('debug')('express:redis');
 
 var client;
 
-module.exports = function (port, host, options) {
+module.exports = function (port, host, options, name) {
   port = port || 6379;
   host = host || '127.0.0.1';
   options = options || {};
+  name = name || 'db';
 
   client = redis.createClient(port, host, options);
 
   var f = function (req, res, next) {
     if (client.connected) {
-      req.redis = client;
+      req[name] = client;
       next();
     }
     else {
       client.on('ready', function () {
         debug('Redis connection ready.');
-        req.redis = client;
+        req[name] = client;
         next();
       });
     }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "express-redis",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Express middleware for a redis connection.",
   "main": "index.js",
   "author": "Elliott Foster <elliottf@codebrews.com> (http://codebrews.com/)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/elliotttf/express-redis.git"
+    "url": "https://github.com/pthm/express-redis.git"
   },
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Elliott Foster <elliottf@codebrews.com> (http://codebrews.com/)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pthm/express-redis.git"
+    "url": "https://github.com/elliotttf/express-redis.git"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
using `request.db` was causing conflicts with node-orm2 so have modified the source to allow a custom name to be provided like so

    app.use(require('express-redis')(6379, '127.0.0.1', {}, 'redis'));

this would make the redis object avaialbe on `request.redis`